### PR TITLE
updated common-tools lib path

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -31,7 +31,7 @@ tags:
   - c
 
 libs:
-  - origin: https://github.com/mamuesp/common-tools
+  - origin: https://github.com/mamuesp-libs/common-tools
   - origin: https://github.com/mamuesp/zip-tools
 
 manifest_version: 2017-09-29


### PR DESCRIPTION
Quick one! 

Your moving of your common-tools lib to mamuesp-libs broke mos.yml.

Thanks for the great tool!